### PR TITLE
Switch to stabilized cargo registry auth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,5 +50,7 @@ runs:
     - name: Set Cargo environment variables
       shell: bash
       run: |
+        registry=$(tr '[:lower:]' '[:upper:]' <<< ${{ inputs.registry }})
         echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> $GITHUB_ENV
-        echo "CARGO_HTTP_USER_AGENT=shipyard ${{ inputs.token }}" >> $GITHUB_ENV
+        echo "CARGO_REGISTRIES_${registry}_TOKEN=${{ inputs.token }}" >> $GITHUB_ENV
+        echo "CARGO_REGISTRIES_${registry}_CREDENTIAL_HELPER=cargo:token" >> $GITHUB_ENV


### PR DESCRIPTION
Switches to the recently stabilized [registry auth](https://doc.rust-lang.org/cargo/reference/registry-authentication.html) for providing credentials to Shipyard instead of the `User-Agent` header.