### PR TITLE
Fix registry authentication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,4 @@ jobs:
 
       - run: cargo init . --bin --name CI
       - run: cargo add logging --registry ${{ matrix.registry }}
+      - run: cargo check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,6 @@ jobs:
           token: ${{ secrets.SHIPYARD_TOKEN }}
           toolchain: ${{ matrix.rust }}
 
-      - run: cargo init . --bin --name CI
+      - run: cargo init . --bin --name ci
       - run: cargo add logging --registry ${{ matrix.registry }}
       - run: cargo check

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,5 @@ runs:
     - name: Set Cargo environment variables
       shell: bash
       run: |
-        registry=$(tr '[:lower:]' '[:upper:]' <<< ${{ inputs.registry }})
         echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> $GITHUB_ENV
-        echo "CARGO_REGISTRIES_${registry}_TOKEN=${{ inputs.token }}" >> $GITHUB_ENV
-        echo "CARGO_REGISTRIES_${registry}_CREDENTIAL_HELPER=cargo:token" >> $GITHUB_ENV
+        echo "CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token" >> $GITHUB_ENV


### PR DESCRIPTION
Fixes the Shipyard.rs registry authentication by explicitly setting the global credential provider to `cargo:token` instead of it being empty. It also adds running `cargo check` to the integration test as it will actually download the crates instead of just the index.