### PR TITLE
Add github.com to known_hosts file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,9 @@ runs:
     - uses: TheHackerApp/setup-ssh@main
       with:
         private-key: ${{ inputs.ssh-private-key }}
-        host: ssh.shipyard.rs
+        host: |
+          ssh.shipyard.rs
+          github.com
 
     - name: Login to Shipyard registry
       shell: bash


### PR DESCRIPTION
Adds `github.com` to the `~/.ssh/known_hosts` file for pulling dependencies from private repositories.